### PR TITLE
Flag type option (boolean type, no explicit value) for CLI

### DIFF
--- a/src/main/kotlin/com/natpryce/konfig/cli.kt
+++ b/src/main/kotlin/com/natpryce/konfig/cli.kt
@@ -89,10 +89,12 @@ fun parseArgs(args: Array<String>,
             this[opt]?.configKey ?: throw Misconfiguration("unrecognised command-line option $arg")
         
         fun storeNextArg(configNameByOpt: Map<String, CommandLineOption>, opt: String) {
-            i++
-            if (i >= args.size) throw Misconfiguration("no argument for $arg command-line option")
-            
-            properties[configNameByOpt.configNameFor(opt)] = CommandLineProperty(arg, args[i])
+            if (i + 1 >= args.size || args[i+1].startsWith("-")) {
+                properties[configNameByOpt.configNameFor(opt)] = CommandLineProperty(arg, "true")
+            } else {
+                i++
+                properties[configNameByOpt.configNameFor(opt)] = CommandLineProperty(arg, args[i])
+            }
         }
         
         when {
@@ -113,10 +115,10 @@ fun parseArgs(args: Array<String>,
                 files.add(arg)
             }
         }
-        
+
         i++
     }
-    
+
     return Pair(CommandLineConfiguration(options.asList(), properties), files)
 }
 

--- a/src/test/kotlin/com/natpryce/unittests/konfig/cli_tests.kt
+++ b/src/test/kotlin/com/natpryce/unittests/konfig/cli_tests.kt
@@ -5,13 +5,7 @@ import com.natpryce.hamkrest.containsSubstring
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
 import com.natpryce.hamkrest.throws
-import com.natpryce.konfig.CommandLineOption
-import com.natpryce.konfig.ConfigurationMap
-import com.natpryce.konfig.Key
-import com.natpryce.konfig.Misconfiguration
-import com.natpryce.konfig.overriding
-import com.natpryce.konfig.parseArgs
-import com.natpryce.konfig.stringType
+import com.natpryce.konfig.*
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -20,6 +14,7 @@ import java.io.ByteArrayOutputStream
 class CommandLineParsing {
     val optX = Key("opt.x", stringType)
     val optY = Key("opt.y", stringType)
+    val optZ = Key("opt.z", booleanType)
 
     @Test
     fun no_options() {
@@ -68,6 +63,15 @@ class CommandLineParsing {
     fun unrecognised_short_option() {
         assertThat({ parseArgs(arrayOf("-a", "foo", "bar"), CommandLineOption(optX, short = "x", long = "opt-x")) },
                 throws<Misconfiguration>())
+    }
+
+    @Test
+    fun flag_long_option() {
+        val (config, args) = parseArgs(arrayOf("--opt-z", "--opt-x", "foo", "bar"), CommandLineOption(optX), CommandLineOption(optZ))
+
+        assertThat(config[optX], equalTo("foo"))
+        assertThat(config[optZ], equalTo(true))
+        assertThat(args, equalTo(listOf("bar")))
     }
 
     @Test


### PR DESCRIPTION
I would like to suggest adding flag type CLI argument support (that is set to true by its mere inclusion).
Similar to --help/-h