### PR TITLE
Subset.locationOf fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ task javadocJar(type: Jar) {
 }
 
 test {
-    include 'com/natpryce/konfig/**'
+    include 'com/natpryce/**'
     scanForTestClasses true
     reports {
         junitXml.enabled = true

--- a/src/main/kotlin/com/natpryce/konfig/konfig.kt
+++ b/src/main/kotlin/com/natpryce/konfig/konfig.kt
@@ -353,7 +353,7 @@ class Subset(
     
     override fun searchPath(key: Key<*>) = configuration.searchPath(full(key))
     
-    override fun locationOf(key: Key<*>) = if (keyIsInSubset(key.name)) configuration.locationOf(key) else null
+    override fun locationOf(key: Key<*>) = configuration.locationOf(full(key))
     
     override fun list() = configuration.list().map { it.first to it.second.filterKeys(this::keyIsInSubset) }
     

--- a/src/test/kotlin/com/natpryce/unittests/konfig/konfig_tests.kt
+++ b/src/test/kotlin/com/natpryce/unittests/konfig/konfig_tests.kt
@@ -24,6 +24,7 @@ import com.natpryce.konfig.wrappedAs
 import org.junit.Test
 import java.io.File
 import java.util.Properties
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -349,6 +350,16 @@ class ConfigSubset {
         
         assertThat("pre/suff-ixed", Subset(fullSet, namePrefix = "a", nameSuffix = "b").list(), equalTo(listOf(
             fullSet.location to mapOf("a.x.b" to "axb"))))
+    }
+
+    @Test
+    fun location_of() {
+        val a = EmptyConfiguration
+        val b = Subset(Subset(ConfigurationMap("a.b.c" to "value"), "a"), "b")
+        val c = EmptyConfiguration
+        val config = a overriding b overriding c
+
+        assertEquals("a.b.c", config.locationOf(Key("c", stringType))?.key?.name)
     }
 }
 


### PR DESCRIPTION
The `Subset.locationOf` function must delegate to the decorated configuration and complete the given key in order to be compatible with all other functions within it. Currently it can find a key but not report its location. This change fixes that.

PS: I had to fix the include pattern in the Gradle build file because the current pattern does not lead to any matches.