### PR TITLE
Possible type mismatch in property_types.kt

### DIFF
--- a/src/main/kotlin/com/natpryce/konfig/property_types.kt
+++ b/src/main/kotlin/com/natpryce/konfig/property_types.kt
@@ -103,7 +103,7 @@ inline fun <reified T : Any> enumType(allowed: Map<String, T>) = enumType(T::cla
 
 fun <T : Any> enumType(enumType: Class<T>, allowed: Map<String, T>) = propertyType(enumType) { str ->
     allowed[str]
-        ?.let { ParseResult.Success(it) }
+        ?.let { ParseResult.Success<T>(it) }
         ?: ParseResult.Failure<T>(IllegalArgumentException("invalid value: $str; must be one of: ${allowed.keys}"))
 }
 


### PR DESCRIPTION
I cloned your repo and opened it in my IDE. An error popped out on line 106 about a type mismatch
```
Type mismatch.
Required: ParseResult<T>
Found:    ParseResult<out T>
```
I don't know if this is important because I've just started to learn Kotlin.
I am running
IntelliJ IDEA 2019.2.3 (Community Edition)
Java 1.8.0_121