### PR TITLE
Use Thread.currentThread().contextClassLoader instead of ClassLoader.…

### DIFF
--- a/src/main/kotlin/com/natpryce/konfig/konfig.kt
+++ b/src/main/kotlin/com/natpryce/konfig/konfig.kt
@@ -6,7 +6,7 @@ import java.io.File
 import java.io.InputStream
 import java.net.URI
 import java.net.URL
-import java.util.Properties
+import java.util.*
 
 /**
  * Error thrown when a mandatory property is missing
@@ -192,7 +192,7 @@ class ConfigurationProperties(
          * Load from resource within the system classloader.
          */
         fun fromResource(resourceName: String): ConfigurationProperties {
-            val classLoader = ClassLoader.getSystemClassLoader()
+            val classLoader = Thread.currentThread().contextClassLoader
             return loadFromResource(resourceName, classLoader.getResource(resourceName))
         }
         


### PR DESCRIPTION
…getSystemClassLoader()

More context: https://bitbucket.org/asomov/snakeyaml/issues/318
I have yet another use case but it is not easy to explain it since it is no open source.

The new way should improve the way to find *.properties in the classpath. It is fully backwards compatible.

